### PR TITLE
Add binding to libscrypt_scrypt native function

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.pl6 gitlab-language=perl
+*.pm6 gitlab-language=perl
+*.p6 gitlab-language=perl
+*.rakumod gitlab-language=perl

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,13 @@
+image: registry.gitlab.com/pheix-pool/docker-core-perl6:latest
+
+before_script:
+  - raku --version
+  - zef update
+  - zef --debug --depsonly install git://github.com/ugexe/zef.git
+test:
+  script:
+    - prove6 -v -Ilib ./t/
+    - zef --verbose install .
+  only:
+    - main
+    - develop

--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,8 @@
 {
   "test-depends": [
-    "LibraryCheck"
+    "LibraryCheck",
+    "MIME::Base64",
+    "Net::Ethereum"
   ],
   "name": "Crypt::LibScrypt",
   "license": "Artistic-2.0",
@@ -27,7 +29,7 @@
     "LibraryCheck",
     "NativeHelpers::Array"
   ],
-  "version": "0.0.4",
+  "version": "0.0.5",
   "resources": [
   ],
   "auth": "zef:jonathanstowe",

--- a/t/040-scrypt.t
+++ b/t/040-scrypt.t
@@ -1,0 +1,31 @@
+#!/usr/bin/env raku
+
+use v6;
+
+use Test;
+use LibraryCheck;
+use Crypt::LibScrypt;
+use MIME::Base64;
+
+if library-exists('scrypt', v0) {
+    my @chars = (|("a" .. "z"), |("A" .. "Z"), |(0 .. 9));
+
+    for ^100 {
+        my $hash;
+        my $password = @chars.pick(20).join;
+
+        my Buf[uint8] $saltbuf;
+        my Buf[uint8] $hashbuf;
+
+        lives-ok { $saltbuf = scrypt-salt }, 'scrypt-salt';
+        lives-ok { $hashbuf = scrypt-scrypt($password, $saltbuf) }, 'scrypt-scrypt';
+        lives-ok { $hash = scrypt-mcf(MIME::Base64.encode($saltbuf, :oneline(True)), MIME::Base64.encode($hashbuf, :oneline(True))) }, 'scrypt-mfc';
+        ok scrypt-verify($hash, $password), 'verify ok';
+    }
+}
+else {
+    skip "No libscrypt, skipping tests";
+}
+
+done-testing;
+# vim: expandtab shiftwidth=4 ft=raku

--- a/t/050-ethkdf.t
+++ b/t/050-ethkdf.t
@@ -1,0 +1,36 @@
+#!/usr/bin/env raku
+
+use v6;
+
+use Test;
+use LibraryCheck;
+use Crypt::LibScrypt;
+use MIME::Base64;
+use Net::Ethereum;
+
+# https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition#scrypt
+
+constant derivedkey = '0xfac192ceb5fd772906bea3e118a69e8bbb5cc24229e20d8766fd298291bba6bd';
+
+if library-exists('scrypt', v0) {
+    my $password  = 'testpassword';
+    my $kdfparams = {
+        dklen => 32,
+        n     => 262144,
+        p     => 8,
+        r     => 1,
+        salt  => 'ab0c7876052600dd703518d6fc3fe8984592145b591fc8fb5c6d43190334ba19',
+    };
+
+    my buf8 $hashbuf;
+    my buf8 $saltbuf = Net::Ethereum.new.hex2buf($kdfparams<salt>);
+
+    lives-ok { $hashbuf = scrypt-scrypt($password, $saltbuf, $kdfparams<n>, $kdfparams<r>, $kdfparams<p>) }, 'scrypt-scrypt';
+    is Net::Ethereum.new.buf2hex($hashbuf.subbuf(0, $kdfparams<dklen>)).lc, derivedkey, 'derived key';
+}
+else {
+    skip "No libscrypt, skipping tests";
+}
+
+done-testing;
+# vim: expandtab shiftwidth=4 ft=raku


### PR DESCRIPTION
I'm working on private key retrieval from [Geth keystore files](https://geth.ethereum.org/docs/developers/dapp-developer/native-accounts). Scrypt is used there as a hash algo for intermediate derived key.

Unfortunately, current `Crypt::LibScrypt` does not provide access to `libscrypt_scrypt` function from `libscrypt`. I have added it. Also I added:

* `libscrypt_salt_gen`
* `libscrypt_mcf`

Tried to follow your code standards, added GitLab CI/CD support and covered newly implemented stuff with unit tests.